### PR TITLE
Incorrect empty line before next boundary

### DIFF
--- a/src/FSNConnection.m
+++ b/src/FSNConnection.m
@@ -716,7 +716,6 @@ NSAssert(!self.didStart, @"method cannot be called after start: %s", __FUNCTION_
         [data appendData:sep];
         [data appendData:valData];
         [data appendData:sep];
-        [data appendData:sep];
     }
     
     [data appendData:[[NSString stringWithFormat:@"--%@--\r\n\r\n", boundary] UTF8Data]];


### PR DESCRIPTION
No empty line / seperator after parameter value before the next boundary. http://www.ietf.org/rfc/rfc1867.txt doesn't specify this newline. This is an issue when uploading an object upload to Amazon's S3 API. It seems their HTTP server treats the newline as part of the value, which is correct according to the RFC. Removing the empty line made the object upload work.
