### PR TITLE
Fix #8: Race condition in FSNConnection

### DIFF
--- a/src/FSNConnection.m
+++ b/src/FSNConnection.m
@@ -473,7 +473,10 @@ NSAssert(!self.didStart, @"method cannot be called after start: %s", __FUNCTION_
 
 - (void)failWithError:(NSError *)error {
     FSNLog(@"failWithError: %@\n  error: %@", self, error);
-    NSAssert(!self.error, @"error already set");
+    if (self.error) {
+        FSNLog(@"failWithError: %@\n error already set: %@", self, self.error);
+        return;
+    }
     self.error = error;
     
     [self performComplete];


### PR DESCRIPTION
We believe that #8 is caused by a race between a failing parse block in the background thread and a background task expiration triggered by `UIKit`. 

In the event that this happens, an assertion exception is not appropriate. The user will not be able to catch this exception in a reasonable way, and the user will typically prefer to be notified of at least one error via `c.error` in the completion block.

@gwk, does this seem reasonable to you? We are hoping this will help us with [this issue](https://github.com/braintree/braintree_ios/issues/22).
