### PR TITLE
Fix warning: Implicit conversion loses integer precision: 'NSUInteger…

### DIFF
--- a/src/FSNConnection.h
+++ b/src/FSNConnection.h
@@ -99,7 +99,7 @@ NSString* stringForRequestMethod(FSNRequestMethod method);
 @property (nonatomic, readonly) float uploadProgress;
 @property (nonatomic, readonly) float downloadProgress;
 
-@property (nonatomic, readonly) int concurrencyCountAtStart;
+@property (nonatomic, readonly) NSUInteger concurrencyCountAtStart;
 @property (nonatomic, readonly) NSTimeInterval startTime;
 @property (nonatomic, readonly) NSTimeInterval challengeInterval;
 @property (nonatomic, readonly) NSTimeInterval responseInterval;

--- a/src/FSNConnection.m
+++ b/src/FSNConnection.m
@@ -58,7 +58,7 @@ NSString* stringForRequestMethod(FSNRequestMethod method) {
 
 @property (nonatomic, readwrite) long long downloadProgressBytes;
 
-@property (nonatomic, readwrite) int concurrencyCountAtStart;
+@property (nonatomic, readwrite) NSUInteger concurrencyCountAtStart;
 @property (nonatomic, readwrite) NSTimeInterval startTime;
 @property (nonatomic, readwrite) NSTimeInterval challengeInterval;
 @property (nonatomic, readwrite) NSTimeInterval responseInterval;


### PR DESCRIPTION
FSNConnection.m:523:36: Implicit conversion loses integer precision: 'NSUInteger' (aka 'unsigned long') to 'int'

![image](https://cloud.githubusercontent.com/assets/893643/8793812/bc19f38c-2fb6-11e5-917f-e1bfe8ff2c34.png)

Reason: The count method of NSArray returns an NSUInteger.

I changed type of concurrencyCountAtStart to NSUInteger.
